### PR TITLE
fix: Handle NA `pattern_subtype` in "hatch" pattern (#106)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: gridpattern
 Type: Package
 Title: 'grid' Pattern Grobs
-Version: 1.4.2
+Version: 1.4.3-0
 Authors@R: c(
         person("Trevor L.", "Davis", role=c("aut", "cre"), email="trevor.l.davis@gmail.com",
                comment = c(ORCID = "0000-0001-6341-4639")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+gridpattern v1.4.3 (development)
+================================
+
+Bug fixes and minor improvements
+--------------------------------
+
+* Fixes a bug where the "hatch" pattern failed when `pattern_subtype` was `NA`
+  (the `{ggpattern}` default) instead of `NULL` (#106).
+
 gridpattern v1.4.2
 ==================
 

--- a/R/pattern-both-hatch.R
+++ b/R/pattern-both-hatch.R
@@ -370,7 +370,11 @@ HATCH_NAME_MAP <- c(
 
 create_pattern_hatch <- function(params, boundary_df, aspect_ratio, legend = FALSE) {
 	type_norm <- gsub("[- ]", "", tolower(params$pattern_type))
-	subtype_norm <- gsub("[- ]", "", tolower(params$pattern_subtype %||% "combinatorial"))
+	subtype <- params$pattern_subtype
+	if (is.null(subtype) || is.na(subtype)) {
+		subtype <- "combinatorial"
+	}
+	subtype_norm <- gsub("[- ]", "", tolower(subtype))
 	is_unicode <- subtype_norm == "unicode"
 	is_fox_davies <- subtype_norm == "foxdavies"
 	is_goodman <- subtype_norm == "goodman"
@@ -395,7 +399,7 @@ create_pattern_hatch <- function(params, boundary_df, aspect_ratio, legend = FAL
 			params$pattern_type,
 			"' is not supported ",
 			"by the '",
-			params$pattern_subtype %||% "combinatorial",
+			subtype,
 			"' subtype."
 		)
 	}

--- a/README.Rmd
+++ b/README.Rmd
@@ -22,7 +22,7 @@ user-specified boundary path with a user-specified pattern. These pattern grobs 
 enhanced versions of the patterns originally contained within
 [Mike FC](https://github.com/coolbutuseless)'s awesome
 [ggpattern](https://github.com/trevorld/ggpattern) package
-as well as original "pch", "polygon_tiling", "regular_polygon", "rose", "text", "wave", and "weave" patterns.
+as well as several original patterns.
 
 `{gridpattern}` currently provides `{grid}` grob support for the following patterns:
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ user-specified boundary path with a user-specified pattern. These pattern grobs 
 enhanced versions of the patterns originally contained within
 [Mike FC](https://github.com/coolbutuseless)'s awesome
 [ggpattern](https://github.com/trevorld/ggpattern) package
-as well as original "pch", "polygon_tiling", "regular_polygon", "rose", "text", "wave", and "weave" patterns.
+as well as several original patterns.
 
 `{gridpattern}` currently provides `{grid}` grob support for the following patterns:
 


### PR DESCRIPTION
* {ggpattern} passes NA (not NULL) as the default for `pattern_subtype`
* Now treat both NULL and NA as "combinatorial".

closes #106

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
